### PR TITLE
add gdb to help with debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ RUN apt-get update && apt-get install -y \
   libasio-dev \
   libtinyxml2-dev \
   liblog4cxx-dev \
-  ros-$ROS_DISTRO-rosidl-generator-dds-idl
+  ros-$ROS_DISTRO-rosidl-generator-dds-idl \
+  gdb


### PR DESCRIPTION
gdb will be helpful in debugging and verifying the rmw . 

This Dockerfile is used to add stuff on top of ROS2 to be used in the combined ROS2/OpenDDS docker image used for RMW/OpenDDS development.